### PR TITLE
Adds header level selection modal

### DIFF
--- a/src/commands/pasteAsHeader.ts
+++ b/src/commands/pasteAsHeader.ts
@@ -1,6 +1,7 @@
 import { Editor, MarkdownView, Notice, Command } from 'obsidian';
 import { CommandContext } from './types';
 import { getClipboardText, insertAtCursor } from '../utilities';
+import { SelectHeaderModal } from '../modals';
 
 /**
  * Create the paste as header command
@@ -15,10 +16,15 @@ export function createPasteAsHeaderCommand(context: CommandContext): Command {
                 return;
             }
 
-            const headerText = `# ${clipboardText.trim()}\n`;
-            console.log('Pasting header: ' + headerText);
-            insertAtCursor(editor, headerText);
-            new Notice(`Pasted as header! ${headerText}`);
+            new SelectHeaderModal(context.app, (headerLevel) => {
+                if (headerLevel === null) {
+                    return;
+                }
+
+                const headerText = `${headerLevel} ${clipboardText.trimStart().trimEnd()}\n`;
+                insertAtCursor(editor, headerText);
+                new Notice(`Pasted as header! ${headerText}`);
+            }).open();
         }
     };
 }

--- a/src/modals/SelectHeaderModal.ts
+++ b/src/modals/SelectHeaderModal.ts
@@ -1,0 +1,55 @@
+import { App, Modal, Setting } from "obsidian";
+
+
+export class SelectHeaderModal extends Modal {
+    constructor(
+        app: App,
+        private onSelect?: (headerLevel: string | null) => void
+    ) {
+        super(app);
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                this.onSelect?.(null);
+                this.close();
+            }
+
+            if (event.key === 'Enter') {
+                const dropdown = contentEl.querySelector('select');
+                if (dropdown) {
+                    const value = (dropdown as HTMLSelectElement).value;
+                    console.log('Chosen header level: ' + value);
+                    this.onSelect?.(value);
+                    this.close();
+                }
+            }
+        });
+
+        new Setting(contentEl)
+            .setName('Header Level')
+            .setDesc('Select a header level')
+            .addDropdown((dropdown) =>
+                dropdown
+                    .addOption('#', 'Heading 1')
+                    .addOption('##', 'Heading 2')
+                    .addOption('###', 'Heading 3')
+                    .addOption('####', 'Heading 4')
+                    .addOption('#####', 'Heading 5')
+                    .setValue('#')
+                    .onChange((value) => {
+                        console.log('Chosen header level: ' + value);
+                        this.onSelect?.(value);
+                        this.close();
+                    })
+            );
+    }
+
+    onClose(): void {
+        super.onClose();
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/modals/SelectLanguageModal.ts
+++ b/src/modals/SelectLanguageModal.ts
@@ -45,5 +45,8 @@ export class SelectLanguageModal extends Modal {
     }
 
     onClose() {
+        super.onClose();
+        const { contentEl } = this;
+        contentEl.empty();
     }
 }

--- a/src/modals/index.ts
+++ b/src/modals/index.ts
@@ -1,1 +1,2 @@
 export { SelectLanguageModal } from './SelectLanguageModal';
+export { SelectHeaderModal } from './SelectHeaderModal';


### PR DESCRIPTION
Implements a modal dialog that allows users to select the desired header level when using the "Paste as header" command.

This enhancement provides more flexibility in formatting pasted content as headers.
